### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 4.0 (unreleased)
 ----------------
 
+- Drop support for ``pkg_resources`` namespace and replace it with PEP 420 native namespace.
+
 - Add support for Python 3.12, 3.13.
 
 - Drop support for Python 3.7, 3.8.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-3.1 (unreleased)
+4.0 (unreleased)
 ----------------
 
 - Add support for Python 3.12, 3.13.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 4.0 (unreleased)
 ----------------
 
-- Drop support for ``pkg_resources`` namespace and replace it with PEP 420 native namespace.
+- Drop support for ``pkg_resources`` namespace and replace it with
+  PEP 420 native namespace.
+  Caution: This change requires to switch all packages in the `five`
+  namespace to versions using a PEP 420 namespace.
 
 - Add support for Python 3.12, 3.13.
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = '3.1.dev0'
+version = '4.0.dev0'
 
 form_requires = [
     'grokcore.formlib >= 1.4',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -38,9 +37,6 @@ setup(name='five.grok',
       author_email='zope-dev@zope.dev',
       url='https://github.com/zopefoundation/five.grok',
       license='ZPL',
-      packages=find_packages('src'),
-      package_dir={'': 'src'},
-      namespace_packages=['five'],
       include_package_data=True,
       zip_safe=False,
       python_requires='>=3.9',

--- a/src/five/__init__.py
+++ b/src/five/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Drop support for ``pkg_resources`` namespace and replace it with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
